### PR TITLE
Upgrade vulnerable Log4J version

### DIFF
--- a/token-exchange-server-sample/pom.xml
+++ b/token-exchange-server-sample/pom.xml
@@ -59,6 +59,9 @@
         </dependency>
     </dependencies>
     <properties>
+        <!-- Log4j version specification can be removed with new version of spring-boot 2.6.2
+        https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
+        <log4j2.version>2.15.0</log4j2.version>
         <java.version>13</java.version>
     </properties>
     <build>

--- a/token-exchange-server-sample/pom.xml
+++ b/token-exchange-server-sample/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>2.6.1</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
According to news, e.g.:
https://www.newscientist.com/article/2301331-log4j-software-bug-is-severe-risk-to-the-entire-internet/ 
a new vulnerability has been reported against the popular Log4J2 library which can allow an attacker to remotely execute code.
Project 'token-exchange-server-sample' is referencing spring-boot-starter that uses log4j as dependency in vulnerable version.
Until new version of 'spring-boot-starter' is released, they introduced a way to enforce fixed version of log4j.
https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

This fix can be adapted once new version 2.6.2 of 'spring-boot-starter' is released.