### PR TITLE
Upgrade Log4J version to 2.16.0

### DIFF
--- a/token-exchange-server-sample/pom.xml
+++ b/token-exchange-server-sample/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <!-- Log4j version specification can be removed with new version of spring-boot 2.6.2
         https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <java.version>13</java.version>
     </properties>
     <build>


### PR DESCRIPTION
According to news, there was discovered a second vulnerability with Log4J which was fixed in 2.16.0.
https://www.zdnet.com/article/second-log4j-vulnerability-found-apache-log4j-2-16-0-released/ 
We changed our solution to use this version.