### PR TITLE
Update Log4J to 2.17.0 due to another vulnerability

### DIFF
--- a/token-exchange-server-sample/pom.xml
+++ b/token-exchange-server-sample/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <!-- Log4j version specification can be removed with new version of spring-boot 2.6.2
         https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
-        <log4j2.version>2.16.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
         <java.version>13</java.version>
     </properties>
     <build>


### PR DESCRIPTION
There was another vulnerability discovered in Log4J that was fixed with version 2,17.0
https://www.zdnet.com/article/apache-releases-new-2-17-0-patch-for-log4j-to-solve-denial-of-service-vulnerability/ 
This version updates to this version. This change may be removed once newer version of spring-boot is released.