### PR TITLE
Upgrade to Spring Boot 2.6.2 that solves issue with vulnerable Log4J …

### DIFF
--- a/token-exchange-server-sample/pom.xml
+++ b/token-exchange-server-sample/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.1</version>
+        <version>2.6.2</version>
     </parent>
     <dependencies>
         <dependency>
@@ -59,9 +59,6 @@
         </dependency>
     </dependencies>
     <properties>
-        <!-- Log4j version specification can be removed with new version of spring-boot 2.6.2
-        https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
-        <log4j2.version>2.17.0</log4j2.version>
         <java.version>13</java.version>
     </properties>
     <build>


### PR DESCRIPTION
Upgrade to Spring Boot 2.6.2 that solves issue with vulnerable Log4J dependency.

According to news, e.g.:
https://www.newscientist.com/article/2301331-log4j-software-bug-is-severe-risk-to-the-entire-internet/
a new vulnerability has been reported against the popular Log4J2 library which can allow an attacker to remotely execute code.
Project 'token-exchange-server-sample' is referencing spring-boot-starter that uses log4j as dependency in vulnerable version.
This is fixed with Log4j version 2.17.0 that is referenced in newly release 2.6.2 version of 'spring-boot-starter'.